### PR TITLE
Force UTF-8 encoding to keep Pygments from crashing Gistie.

### DIFF
--- a/app/models/highlighted_source.rb
+++ b/app/models/highlighted_source.rb
@@ -72,6 +72,7 @@ class HighlightedSource
   end
 
   def pygments
+    @source.force_encoding("UTF-8")
     Pygments.highlight(@source, :lexer => lexer)
   end
 end


### PR DESCRIPTION
Looks like non-utf text pasted in makes Pygments crash. This forces the source to UTF-8 preventing these sorts of crashes.

```
Processing by GistsController#show as HTML
  Parameters: {"id"=>"6"}
  Gist Load (0.1ms)  SELECT "gists".* FROM "gists" WHERE "gists"."id" = ? LIMIT 1  [["id", "6"]]
  Rendered gists/_revisions.html.erb (0.5ms)
Couldn't find lexer for Text: Traceback (most recent call last):
  File "/home/gpurkins/.rvm/gems/ruby-1.9.3-p194/gems/pygments.rb-0.3.2/lib/pygments/mentos.py", line 303, in start
    res = self.get_data(method, lexer, args, kwargs, text)
  File "/home/gpurkins/.rvm/gems/ruby-1.9.3-p194/gems/pygments.rb-0.3.2/lib/pygments/mentos.py", line 179, in get_data
    lexer = self.return_lexer(None, args, kwargs, text)
  File "/home/gpurkins/.rvm/gems/ruby-1.9.3-p194/gems/pygments.rb-0.3.2/lib/pygments/mentos.py", line 98, in return_lexer
    return lexers.get_lexer_for_filename(name, **inputs)
  File "/home/gpurkins/.rvm/gems/ruby-1.9.3-p194/gems/pygments.rb-0.3.2/vendor/pygments-main/pygments/lexers/__init__.py", line 122, in get_lexer_for_filename
    raise ClassNotFound('no lexer for filename %r found' % _fn)
ClassNotFound: no lexer for filename u'Text' found
```

I can supply some test text, but not sure how to do it. I had a friend copy-pasting from a PDF and it crashed our install of Gistie.

This fixes issue #5.
